### PR TITLE
Fixing issue with removing historical loads

### DIFF
--- a/bin/stardog_load.sh
+++ b/bin/stardog_load.sh
@@ -326,7 +326,6 @@ if [[ $terminology == "ncit" ]] && [[ $weekly -eq 0 ]]; then
 fi
 
 # Remove older versions here
-source ~/.bashrc
 maxVersions=1
 if [[ `grep -c maxVersions $DIR/../config/metadata/$terminology.json` -gt 0 ]]; then
     maxVersions=`grep maxVersions $DIR/../config/metadata/$terminology.json | perl -pe 's/.*\:\s*(\d+),.*/$1/;'`

--- a/bin/stardog_load.sh
+++ b/bin/stardog_load.sh
@@ -326,6 +326,7 @@ if [[ $terminology == "ncit" ]] && [[ $weekly -eq 0 ]]; then
 fi
 
 # Remove older versions here
+source ~/.bashrc
 maxVersions=1
 if [[ `grep -c maxVersions $DIR/../config/metadata/$terminology.json` -gt 0 ]]; then
     maxVersions=`grep maxVersions $DIR/../config/metadata/$terminology.json | perl -pe 's/.*\:\s*(\d+),.*/$1/;'`

--- a/bin/transforms/hgnc.sh
+++ b/bin/transforms/hgnc.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 dir=`pwd | perl -pe 's#/cygdrive/c#C:#;'`
-APP_HOME="${2:-$dir/../../}"
-CONFIG_DIR="$APP_HOME/config/transforms/hgnc"
-LIB_HOME="$APP_HOME/lib"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+EVS_OPS_HOME=$DIR/../..
+CONFIG_DIR="$EVS_OPS_HOME/config/transforms/hgnc"
+LIB_HOME="$EVS_OPS_HOME/lib"
 # We sort on version to determine "latest" programmatically in a consistent way
 date=`/bin/date +%Y%m`
 
@@ -14,15 +15,6 @@ cleanup() {
     if [ "$code" != "" ]; then
       exit $code
     fi
-}
-
-
-setup(){
-  echo "hgnc.sh:Setting up transform script"
-  if [[ ! -d $APP_HOME ]]; then
-      echo "ERROR: hgnc.sh:APP_HOME is not set"
-      exit 1
-  fi
 }
 
 download_hgnc_file() {
@@ -66,8 +58,6 @@ set_version(){
   rm HGNC_$date_tmp.owl
 }
 
-setup
-#download_hgnc_file $1
 create_properties_file $1
 create_owl_file
 set_version


### PR DESCRIPTION
The problem is that the APP_HOME is setup as `export APP_HOME=~/evsrestapi-operations/`. However that directory is only used for locating the config directory. The real APP_HOME where deployments happen is in `/local/content/evsrestapi/evsrestapi-operations`. This is setup in config that we added recently to setup.sh. However, there are other scripts that depend on the APP_HOME to locate the configuration. So the change there is to reset the APP_HOME after the transformations happen. This feels fishy. @bcarlsenca Maybe there is an alternative solution that we can try