### PR TITLE
reformat ncit extraSubsets

### DIFF
--- a/config/metadata/ncit.json
+++ b/config/metadata/ncit.json
@@ -34,16 +34,11 @@
 	"subset": [
 		"C54443"
 	],
-	"extraSubsets": [
-	{
-		"C6283": "C143048"
+	"extraSubsets":	{
+		"C6283": "C143048",
+		"C190573": "C6283",
+		"C4005": "C6283",
 	},
-	{
-		"C190573": "C6283"
-	},
-	{
-		"C4005": "C6283"
-	}],
 	"sources": {
 		"ACC": "American College of Cardiology",
 		"ACC/AHA": "American College of Cardiology / American Heart Association",


### PR DESCRIPTION
need to reformat extraSubset to be more in line with the other maps in terminologyMetadata, avoiding reading issues when getting the data